### PR TITLE
feat: esm support, misc postgres fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Follow these steps in order to properly initialize the Tusk Drift SDK:
 
 Create a separate file (e.g. `tdInit.ts`) to initialize the Tusk Drift SDK. This ensures the SDK is initialized as early as possible before any other modules are loaded.
 
+#### For CommonJS Applications
+
 ```typescript
 // tdInit.ts
 import { TuskDrift } from "@use-tusk/drift-node-sdk";
@@ -71,6 +73,33 @@ TuskDrift.initialize({
 
 export { TuskDrift };
 ```
+
+#### For ESM Applications
+
+ESM applications require additional setup to properly intercept module imports:
+
+```typescript
+// tdInit.ts
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+// Register the ESM loader
+// This enables interception of ESM module imports
+register('@use-tusk/drift-node-sdk/hook.mjs', pathToFileURL('./'));
+
+import { TuskDrift } from "@use-tusk/drift-node-sdk";
+
+// Initialize SDK immediately
+TuskDrift.initialize({
+  apiKey: process.env.TUSK_DRIFT_API_KEY,
+  env: process.env.ENV,
+  logLevel: process.env.TUSK_DRIFT_LOG_LEVEL,
+});
+
+export { TuskDrift };
+```
+
+**Why the ESM loader is needed**: ESM imports are statically analyzed and hoisted, meaning all imports are resolved before any code runs. The `register()` call sets up Node.js loader hooks that intercept module imports, allowing the SDK to instrument packages like `postgres`, `http`, etc. Without this, the SDK cannot patch ESM modules.
 
 #### Configuration Options
 
@@ -107,7 +136,9 @@ export { TuskDrift };
 
 ### 2. Import SDK at Application Entry Point
 
-In your main server file (e.g., `server.ts`, `index.ts`, `app.ts`), import the initialized SDK **at the very top**, before any other imports:
+#### For CommonJS Applications
+
+In your main server file (e.g., `server.ts`, `index.ts`, `app.ts`), require the initialized SDK **at the very top**, before any other requires:
 
 ```typescript
 // server.ts
@@ -118,7 +149,24 @@ import { TuskDrift } from "./tdInit"; // MUST be the first import
 // Your application setup...
 ```
 
-> **IMPORTANT**: Ensure NO require/import calls are made before importing the SDK initialization file. This guarantees proper instrumentation of all dependencies.
+> **IMPORTANT**: Ensure NO require calls are made before requiring the SDK initialization file. This guarantees proper instrumentation of all dependencies.
+
+#### For ESM Applications
+
+For ESM applications, you **cannot** control import order within your application code because all imports are hoisted. Instead, use the `--import` flag:
+
+**Update your package.json scripts**:
+
+```json
+{
+  "scripts": {
+    "dev": "node --import ./dist/tdInit.js dist/server.js"
+    "dev:record": "TUSK_DRIFT_MODE=RECORD node --import ./dist/tdInit.js dist/server.js"
+  }
+}
+```
+
+**Why `--import` is required for ESM**: In ESM, all `import` statements are hoisted and evaluated before any code runs, making it impossible to control import order within a file. The `--import` flag ensures the SDK initialization (including loader registration) happens in a separate phase before your application code loads, guaranteeing proper module interception.
 
 ### 3. Update Configuration File
 

--- a/hook.mjs
+++ b/hook.mjs
@@ -1,25 +1,5 @@
-/*!
- * Copyright The OpenTelemetry Authors
- * Copyright Use Tusk
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // ESM loader hooks for drift-node-sdk instrumentation
 // This file enables ESM module interception by delegating to import-in-the-middle
-//
-// Usage: node --experimental-loader=@use-tusk/drift-node-sdk/hook.mjs --import ./telemetry.js app.js
-
 import {
   initialize,
   load,

--- a/hook.mjs
+++ b/hook.mjs
@@ -1,0 +1,31 @@
+/*!
+ * Copyright The OpenTelemetry Authors
+ * Copyright Use Tusk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ESM loader hooks for drift-node-sdk instrumentation
+// This file enables ESM module interception by delegating to import-in-the-middle
+//
+// Usage: node --experimental-loader=@use-tusk/drift-node-sdk/hook.mjs --import ./telemetry.js app.js
+
+import {
+  initialize,
+  load,
+  resolve,
+  getFormat,
+  getSource,
+} from 'import-in-the-middle/hook.mjs';
+
+export { initialize, load, resolve, getFormat, getSource };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@use-tusk/drift-schemas": "^0.1.10",
         "express": "^5.1.0",
         "google-protobuf": "^4.0.0",
-        "import-in-the-middle": "^1.8.1",
+        "import-in-the-middle": "^1.14.4",
         "install": "^0.13.0",
         "js-yaml": "^4.1.0",
         "jsonpath": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@use-tusk/drift-schemas": "^0.1.10",
         "express": "^5.1.0",
         "google-protobuf": "^4.0.0",
+        "import-in-the-middle": "^1.8.1",
         "install": "^0.13.0",
         "js-yaml": "^4.1.0",
         "jsonpath": "^1.1.1",
@@ -1406,6 +1407,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/@opentelemetry/instrumentation/node_modules/import-in-the-middle": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
     "node_modules/@opentelemetry/otlp-exporter-base": {
       "version": "0.45.1",
       "license": "Apache-2.0",
@@ -2557,6 +2570,18 @@
     },
     "node_modules/acorn-import-assertions": {
       "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "deprecated": "package has been renamed to acorn-import-attributes",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
@@ -4386,11 +4411,13 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.4.2",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.4.tgz",
+      "integrity": "sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "type": "module",
   "files": [
-    "dist/**"
+    "dist/**",
+    "hook.mjs"
   ],
   "publishConfig": {
     "access": "public",
@@ -75,6 +76,7 @@
     "@use-tusk/drift-schemas": "^0.1.10",
     "express": "^5.1.0",
     "google-protobuf": "^4.0.0",
+    "import-in-the-middle": "^1.8.1",
     "install": "^0.13.0",
     "js-yaml": "^4.1.0",
     "jsonpath": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@use-tusk/drift-schemas": "^0.1.10",
     "express": "^5.1.0",
     "google-protobuf": "^4.0.0",
-    "import-in-the-middle": "^1.8.1",
+    "import-in-the-middle": "^1.14.4",
     "install": "^0.13.0",
     "js-yaml": "^4.1.0",
     "jsonpath": "^1.1.1",

--- a/src/instrumentation/core/baseClasses/TdInstrumentationBase.ts
+++ b/src/instrumentation/core/baseClasses/TdInstrumentationBase.ts
@@ -103,10 +103,6 @@ export abstract class TdInstrumentationBase extends TdInstrumentationAbstract {
       // Register ESM hook (import-in-the-middle)
       const esmHook = new HookImport([module.name], { internals: false }, hookFn);
       this._hooks.push(esmHook);
-
-      logger.debug(
-        `Registered hooks for module ${module.name} (instrumentation: ${this.instrumentationName})`,
-      );
     }
   }
 
@@ -115,34 +111,17 @@ export abstract class TdInstrumentationBase extends TdInstrumentationAbstract {
   }
 
   /**
-   * Mark a module as patched. Works for both CJS and ESM modules.
-   * For CJS, sets _tdPatched property. For ESM, adds to WeakSet (since ESM exports are immutable).
+   * Mark a module as patched.
    */
   protected markModuleAsPatched(moduleExports: any): void {
-    try {
-      // Try to set property (works for CJS)
-      moduleExports._tdPatched = true;
-    } catch {
-      // If that fails (ESM), add to WeakSet
-      if (typeof moduleExports === "object" && moduleExports !== null) {
-        TdInstrumentationBase._patchedModules.add(moduleExports);
-      }
-    }
+    TdInstrumentationBase._patchedModules.add(moduleExports);
   }
 
   /**
-   * Check if a module has already been patched. Works for both CJS and ESM modules.
+   * Check if a module has already been patched.
    */
   protected isModulePatched(moduleExports: any): boolean {
-    // Check property first (CJS)
-    if (moduleExports._tdPatched) {
-      return true;
-    }
-    // Check WeakSet (ESM)
-    if (typeof moduleExports === "object" && moduleExports !== null) {
-      return TdInstrumentationBase._patchedModules.has(moduleExports);
-    }
-    return false;
+    return TdInstrumentationBase._patchedModules.has(moduleExports);
   }
 
   private _onRequire(

--- a/src/instrumentation/core/utils/shimmerUtils.ts
+++ b/src/instrumentation/core/utils/shimmerUtils.ts
@@ -19,7 +19,7 @@ export function wrap<T = any>(
   target: any,
   propertyName: string,
   wrapper: (original: T) => T,
-): void {
+): T | void {
   if (typeof target[propertyName] !== "function") {
     logger.warn(`Cannot wrap non-function property: ${propertyName}`);
     return;
@@ -44,4 +44,5 @@ export function wrap<T = any>(
   (wrapped as any)._propertyName = propertyName;
 
   target[propertyName] = wrapped;
+  return wrapped;
 }

--- a/src/instrumentation/libraries/http/Instrumentation.ts
+++ b/src/instrumentation/libraries/http/Instrumentation.ts
@@ -84,7 +84,7 @@ export class HttpInstrumentation extends TdInstrumentationBase {
     const protocolUpper = protocol.toUpperCase();
     logger.debug(`[HttpInstrumentation] Patching ${protocolUpper} module in ${this.mode} mode`);
 
-    if (httpModule._tdPatched) {
+    if (this.isModulePatched(httpModule)) {
       logger.debug(`[HttpInstrumentation] ${protocolUpper} module already patched, skipping`);
       return httpModule;
     }
@@ -98,7 +98,7 @@ export class HttpInstrumentation extends TdInstrumentationBase {
       logger.debug(`[HttpInstrumentation] Wrapped Server.prototype.emit for ${protocolUpper}`);
     }
 
-    httpModule._tdPatched = true;
+    this.markModuleAsPatched(httpModule);
     logger.debug(`[HttpInstrumentation] ${protocolUpper} module patching complete`);
 
     return httpModule;

--- a/src/instrumentation/libraries/http/Instrumentation.ts
+++ b/src/instrumentation/libraries/http/Instrumentation.ts
@@ -97,8 +97,11 @@ export class HttpInstrumentation extends TdInstrumentationBase {
       // In ESM: import http from 'http' gives { default: <http module>, request: ..., get: ... }
       // Users may access http.request (namespace) OR http.default.request (default export)
       // We need to ensure both are wrapped
-      this._wrap(httpModule.default, "request", this._getRequestPatchFn(protocol));
-      this._wrap(httpModule.default, "get", this._getGetPatchFn(protocol));
+      if (httpModule.default) {
+        // Should always be true in ESM mode, but just in case
+        this._wrap(httpModule.default, "request", this._getRequestPatchFn(protocol));
+        this._wrap(httpModule.default, "get", this._getGetPatchFn(protocol));
+      }
     } else {
       // Wrap methods on the http/https module namespace
       this._wrap(httpModule, "request", this._getRequestPatchFn(protocol));

--- a/src/instrumentation/libraries/http/README.md
+++ b/src/instrumentation/libraries/http/README.md
@@ -60,3 +60,12 @@ HTTP request and response instrumentation for both client (outbound requests) an
 - Uses `TUSK_SKIP_HEADER` to identify and bypass SDK requests
 - Checks `isTuskDriftIngestionUrl()` to avoid instrumenting drift exports
 - Prevents infinite loops and span pollution
+
+### ESM-Specific Handling
+
+The HTTP instrumentation handles both CommonJS and ESM modules:
+
+- **ESM Detection**: Uses `Symbol.toStringTag === 'Module'` to detect ESM modules
+- **Default Export Sync**: When ESM is detected, wrapped methods are also set on `moduleExports.default` to ensure both named and default imports work correctly
+
+This ensures proper instrumentation whether users import via `import http from 'http'` (default) or `import * as http from 'http'` (namespace).

--- a/src/instrumentation/libraries/http/types.ts
+++ b/src/instrumentation/libraries/http/types.ts
@@ -61,6 +61,7 @@ export interface HttpServerOutputValue {
 }
 
 export interface HttpModuleExports {
+  default?: any;
   _connectionListener: Function;
   METHODS: string[];
   STATUS_CODES: { [code: number]: string };
@@ -82,6 +83,7 @@ export interface HttpModuleExports {
 }
 
 export interface HttpsModuleExports {
+  default?: any;
   Agent: typeof Agent;
   globalAgent: Agent;
   Server: typeof Server;

--- a/src/instrumentation/libraries/http/types.ts
+++ b/src/instrumentation/libraries/http/types.ts
@@ -79,7 +79,6 @@ export interface HttpModuleExports {
   maxHeaderSize: number;
   globalAgent: Agent;
   // Custom property added by our instrumentation
-  _tdPatched?: boolean;
 }
 
 export interface HttpsModuleExports {
@@ -90,5 +89,4 @@ export interface HttpsModuleExports {
   get: Function;
   request: Function;
   // Custom property added by our instrumentation
-  _tdPatched?: boolean;
 }

--- a/src/instrumentation/libraries/jsonwebtoken/Instrumentation.ts
+++ b/src/instrumentation/libraries/jsonwebtoken/Instrumentation.ts
@@ -45,7 +45,7 @@ export class JsonwebtokenInstrumentation extends TdInstrumentationBase {
   private _patchJsonwebtokenModule(
     jwtModule: JsonwebtokenModuleExports,
   ): JsonwebtokenModuleExports {
-    if (jwtModule._tdPatched) {
+    if (this.isModulePatched(jwtModule)) {
       logger.debug(`[JsonwebtokenInstrumentation] jsonwebtoken module already patched, skipping`);
       return jwtModule;
     }
@@ -67,7 +67,7 @@ export class JsonwebtokenInstrumentation extends TdInstrumentationBase {
       logger.debug(`[JsonwebtokenInstrumentation] Wrapped jwt.sign`);
     }
 
-    jwtModule._tdPatched = true;
+    this.markModuleAsPatched(jwtModule);
     logger.debug(`[JsonwebtokenInstrumentation] jsonwebtoken module patching complete`);
 
     return jwtModule;

--- a/src/instrumentation/libraries/jsonwebtoken/JsonwebtokenInstrumentation.test.ts
+++ b/src/instrumentation/libraries/jsonwebtoken/JsonwebtokenInstrumentation.test.ts
@@ -50,7 +50,6 @@ const mockJsonwebtokenModule = {
       this.date = date;
     }
   },
-  _tdPatched: false,
 };
 
 // Test payload and secrets

--- a/src/instrumentation/libraries/jsonwebtoken/types.ts
+++ b/src/instrumentation/libraries/jsonwebtoken/types.ts
@@ -8,7 +8,6 @@ export interface JsonwebtokenModuleExports {
   JsonWebTokenError: any;
   TokenExpiredError: any;
   NotBeforeError: any;
-  _tdPatched?: boolean;
 }
 
 export interface JsonwebtokenInstrumentationConfig extends TdInstrumentationConfig {

--- a/src/instrumentation/libraries/jwks-rsa/Instrumentation.ts
+++ b/src/instrumentation/libraries/jwks-rsa/Instrumentation.ts
@@ -32,7 +32,7 @@ export class JwksRsaInstrumentation extends TdInstrumentationBase {
       `[JwksRsaInstrumentation] Patching jwks-rsa module, current mode: ${this.tuskDrift.getMode()}`,
     );
 
-    if (jwksModule._tdPatched) {
+    if (this.isModulePatched(jwksModule)) {
       logger.debug(`[JwksRsaInstrumentation] jwks-rsa module already patched, skipping`);
       return jwksModule;
     }
@@ -58,7 +58,7 @@ export class JwksRsaInstrumentation extends TdInstrumentationBase {
       logger.debug(`[JwksRsaInstrumentation] Patched expressJwtSecret method`);
     }
 
-    jwksModule._tdPatched = true;
+    this.markModuleAsPatched(jwksModule);
 
     logger.debug(`[JwksRsaInstrumentation] jwks-rsa module patching complete`);
     return jwksModule;

--- a/src/instrumentation/libraries/jwks-rsa/types.ts
+++ b/src/instrumentation/libraries/jwks-rsa/types.ts
@@ -3,7 +3,6 @@ import { TdInstrumentationConfig } from "../../core/baseClasses/TdInstrumentatio
 
 export interface JwksRsaModuleExports {
   (options: JwksClientOptions): JwksClient;
-  _tdPatched?: boolean;
 }
 
 export interface JwksRsaInstrumentationConfig extends TdInstrumentationConfig {

--- a/src/instrumentation/libraries/pg/Instrumentation.ts
+++ b/src/instrumentation/libraries/pg/Instrumentation.ts
@@ -51,7 +51,7 @@ export class PgInstrumentation extends TdInstrumentationBase {
   private _patchPgModule(pgModule: PgModuleExports): PgModuleExports {
     logger.debug(`[PgInstrumentation] Patching PG module in ${this.mode} mode`);
 
-    if (pgModule._tdPatched) {
+    if (this.isModulePatched(pgModule)) {
       logger.debug(`[PgInstrumentation] PG module already patched, skipping`);
       return pgModule;
     }
@@ -68,7 +68,7 @@ export class PgInstrumentation extends TdInstrumentationBase {
       logger.debug(`[PgInstrumentation] Wrapped Client.prototype.connect`);
     }
 
-    pgModule._tdPatched = true;
+    this.markModuleAsPatched(pgModule);
     logger.debug(`[PgInstrumentation] PG module patching complete`);
 
     return pgModule;
@@ -572,7 +572,7 @@ export class PgInstrumentation extends TdInstrumentationBase {
   }
 
   private _patchPgPoolModule(pgPoolModule: PgPoolModuleExports): PgPoolModuleExports {
-    if (pgPoolModule._tdPatched) {
+    if (this.isModulePatched(pgPoolModule)) {
       logger.debug(`[PgInstrumentation] PG Pool module already patched, skipping`);
       return pgPoolModule;
     }
@@ -589,7 +589,7 @@ export class PgInstrumentation extends TdInstrumentationBase {
       logger.debug(`[PgInstrumentation] Wrapped Pool.prototype.connect`);
     }
 
-    pgPoolModule._tdPatched = true;
+    this.markModuleAsPatched(pgPoolModule);
     logger.debug(`[PgInstrumentation] PG Pool module patching complete`);
 
     return pgPoolModule;

--- a/src/instrumentation/libraries/pg/types.ts
+++ b/src/instrumentation/libraries/pg/types.ts
@@ -32,13 +32,11 @@ export interface PgModuleExports {
   escapeIdentifier: typeof escapeIdentifier;
   escapeLiteral: typeof escapeLiteral;
   Result: typeof Result;
-  _tdPatched?: boolean;
 }
 
 // pg-pool exports a constructor function, so we type it as a constructor that returns Pool
 export interface PgPoolModuleExports {
   prototype: Pool;
-  _tdPatched?: boolean;
 }
 
 export interface PgInstrumentationConfig extends TdInstrumentationConfig {

--- a/src/instrumentation/libraries/postgres/README.md
+++ b/src/instrumentation/libraries/postgres/README.md
@@ -153,6 +153,15 @@ Returns `PendingQuery` wrapper with additional methods:
 }
 ```
 
+### ESM-Specific Handling
+
+The postgres instrumentation requires special handling for ESM because the `postgres` package exports a default function:
+
+- **ESM**: The function is accessed via `moduleExports.default`, so we wrap that property directly
+- **CommonJS**: The function is the module itself, so we create a wrapped function and copy all properties
+
+This is automatically detected using `Symbol.toStringTag === 'Module'`. See the comments in `Instrumentation.ts` for implementation details.
+
 ### Version Support
 
 - **postgres**: Version 3.x (postgres.js driver)

--- a/src/instrumentation/libraries/postgres/types.ts
+++ b/src/instrumentation/libraries/postgres/types.ts
@@ -23,7 +23,6 @@ export interface PostgresConnectionInputValue {
 export interface PostgresModuleExports {
   sql?: Function;
   default?: Function;
-  _tdPatched?: boolean;
   [key: string]: any;
 }
 

--- a/src/instrumentation/libraries/postgres/types.ts
+++ b/src/instrumentation/libraries/postgres/types.ts
@@ -36,10 +36,10 @@ export interface PostgresInstrumentationConfig extends TdInstrumentationConfig {
 /**
  * postgres.js result format with metadata
  */
-export interface PostgresResult<T = any> {
-  rows?: T[];
-  command: string;
-  count: number;
+export interface PostgresResult {
+  rows?: PostgresRow[];
+  command?: string;
+  count?: number;
 }
 
 /**
@@ -54,10 +54,26 @@ export type PostgresRow = Record<string, any>;
  * - null/undefined
  */
 export type PostgresConvertedResult =
-  | PostgresResult<PostgresRow>
-  | PostgresRow[]
-  | null
-  | undefined;
+  | PostgresResult
+  | PostgresRow[];
+
+export type PostgresOutputValueType = {
+  rows?: PostgresRow[];
+  command?: string;
+  count?: number;
+  _tdOriginalFormat: PostgresReturnType;
+}
+
+// Add this as a private method in your class
+export function isPostgresOutputValueType(value: any): value is PostgresOutputValueType {
+  return (
+    value !== null &&
+    value !== undefined &&
+    typeof value === "object" &&
+    "_tdOriginalFormat" in value &&
+    Object.values(PostgresReturnType).includes(value._tdOriginalFormat)
+  );
+}
 
 /**
  * Transaction result
@@ -66,4 +82,9 @@ export interface PostgresTransactionResult {
   status: "committed" | "rolled_back";
   result?: any;
   error?: string;
+}
+
+export enum PostgresReturnType {
+  ARRAY = "array",
+  OBJECT = "object",
 }

--- a/src/instrumentation/libraries/tcp/Instrumentation.ts
+++ b/src/instrumentation/libraries/tcp/Instrumentation.ts
@@ -44,7 +44,7 @@ export class TcpInstrumentation extends TdInstrumentationBase {
   private _patchNetModule(netModule: any): any {
     logger.debug(`[TcpInstrumentation] Patching NET module in ${this.mode} mode`);
 
-    if (netModule._tdPatched) {
+    if (this.isModulePatched(netModule)) {
       logger.debug(`[TcpInstrumentation] NET module already patched, skipping`);
       return netModule;
     }
@@ -70,7 +70,7 @@ export class TcpInstrumentation extends TdInstrumentationBase {
       return self._handleTcpCall("write", originalWrite, args, this);
     };
 
-    netModule._tdPatched = true;
+    this.markModuleAsPatched(netModule);
     return netModule;
   }
 


### PR DESCRIPTION
## Overview

This PR adds ESM support to the Tusk Drift Node.js SDK, enabling instrumentation of ESM applications alongside existing CJS support

## Updates
- Added `import-in-the-middle` (created by [Datadog](https://opensource.datadoghq.com/projects/node/#the-import-in-the-middle-library)) for ESM module interception alongside existing `require-in-the-middle` for CJS
- New `hook.mjs` file that exports loader hooks for ESM module interception
- Updated`TdInstrumentationBase` to register both CommonJS and ESM hooks simultaneously
- Instrumentations that require special handling
  - **HTTP/HTTPS**: Syncs wrapped methods to both namespace and default exports for ESM compatibility
  - **Postgres**: Special handling for default function exports in ESM (wraps `.default` property vs. returning wrapped function)
  - Misc fixes to postgres instrumentation

## Packages That Require Custom ESM Support

Most packages don't need special handling because they export objects with methods we can wrap:
```javascript
// pg package exports: { Client: [Function], Pool: [Function] }
// Same in both CJS and ESM - we wrap properties on the object
this._wrap(moduleExports, 'Client', wrapper);
```

Special handling is only needed for default function exports like the `postgres` package:
- **CJS**: `moduleExports` is the function directly
- **ESM**: The function is in `moduleExports.default` (ESM namespace object)

```javascript
// postgres package structure differs:
// CJS: moduleExports = [Function: postgres]  
// ESM: moduleExports = { default: [Function: postgres], [Symbol.toStringTag]: 'Module' }

const isESM = moduleExports[Symbol.toStringTag] === 'Module';
if (isESM) {
  this._wrap(moduleExports, 'default', wrapper);  // Wrap the .default property
} else {
  return wrappedFunction;  // Return wrapped function for CJS
}
```

If the package exports an object with properties, no special handling is needed. If it exports a function or primitive directly, special ESM handling is required

## Docs + setup
- Updated README with instructions on how to set up Tusk Drift on an ESM service
  - @marcel-tan we will need to update tusk docs to reflect README changes, we can wait to do this before releasing
- Updated CONTRIBUTING.md explain CJS and ESM differences and special handling reasoning

NOTE: haven't fully tested if other instrumentations require updates to support ESM imports. Next PR will be e2e tests which will include tests for all instrumentation in CJS and ESM. Any updates to other instrumentations will be made in that PR 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ESM module interception via import-in-the-middle, updates core/instrumentations for ESM compatibility, refines postgres handling, and updates docs/deps.
> 
> - **Core/Infra**
>   - Add ESM interception using `import-in-the-middle` with new loader `hook.mjs`; keep CJS via `require-in-the-middle`.
>   - Update `TdInstrumentationBase` to register both CJS/ESM hooks and track patched modules via `WeakSet`.
>   - `shimmerUtils.wrap()` now returns the wrapped function.
>   - Publish `hook.mjs`; add `import-in-the-middle` dependency.
> - **Instrumentations**
>   - **HTTP/HTTPS**: ESM-aware wrapping (namespace and `default`), use central patched-module tracking.
>   - **postgres**: Special ESM handling for default function export; wrap `.default` for ESM and return a wrapped function for CJS; copy all properties; refine result/output handling and type conversion helpers.
>   - **pg / pg-pool, jsonwebtoken, jwks-rsa, tcp**: Switch to central patched-module tracking (remove `_tdPatched` flags).
> - **Types/Result handling (postgres)**
>   - Introduce `PostgresReturnType`, `PostgresOutputValueType`, `isPostgresOutputValueType`; adjust `convertPostgresTypes` and span output to include `_tdOriginalFormat` metadata.
> - **Docs**
>   - README: Add ESM setup using `module.register()` / `--import`, loader rationale, and entry ordering; expand init steps.
>   - CONTRIBUTING: Explain CJS vs ESM interception and when special ESM handling is required.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 587743b0eb7c5d05bb518453953ec5f7789b5686. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->