### PR TITLE
fix(coverage): use dynamic import for ast-v8-to-istanbul to fix tsx

### DIFF
--- a/src/core/coverageProcessor.test.ts
+++ b/src/core/coverageProcessor.test.ts
@@ -60,6 +60,7 @@ test("takeAndProcessSnapshot: skips coverage files without user scripts", async 
             {
               functionName: "",
               ranges: [{ startOffset: 0, endOffset: 10, count: 1 }],
+              isBlockCoverage: false,
             },
           ],
         },

--- a/src/core/coverageProcessor.ts
+++ b/src/core/coverageProcessor.ts
@@ -38,9 +38,11 @@ export interface V8CoverageRange {
 }
 
 export interface V8FunctionCoverage {
-  functionName?: string;
+  // V8 always emits these per Node's Profiler.FunctionCoverage contract; matching that
+  // shape lets us pass V8FunctionCoverage[] to ast-v8-to-istanbul.convert without a cast.
+  functionName: string;
   ranges: V8CoverageRange[];
-  isBlockCoverage?: boolean;
+  isBlockCoverage: boolean;
 }
 
 export interface V8ScriptCoverage {
@@ -331,7 +333,10 @@ export async function processV8CoverageFile(
         code: codeForConvert,
         ast,
         coverage: { functions: script.functions, url: script.url },
-        ...(sourceMap ? { sourceMap } : {}),
+        // sourceMap is parsed JSON — loadSourceMap returns Record<string, unknown> rather
+        // than committing to a specific source-map type from a transitive dep. Cast to the
+        // shape convert expects.
+        ...(sourceMap ? { sourceMap: sourceMap as Parameters<typeof convert>[0]["sourceMap"] } : {}),
         ...(cjsWrapperLength ? { wrapperLength: cjsWrapperLength } : {}),
       });
 

--- a/src/core/coverageProcessor.ts
+++ b/src/core/coverageProcessor.ts
@@ -258,10 +258,13 @@ export async function processV8CoverageFile(
   includeAll: boolean = false,
   preParsedData?: V8CoverageData,
 ): Promise<CoverageResult> {
-  // Lazy-loaded: these are only needed when coverage is enabled, which is opt-in.
-  // Using require() avoids loading them on every SDK startup (adds ~50ms + memory).
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { convert } = require("ast-v8-to-istanbul");
+  // Lazy-loaded: only needed when coverage is enabled (opt-in), saves ~50ms + memory at SDK startup.
+  // Using dynamic import (not require) because ast-v8-to-istanbul is ESM-only and pulls in
+  // estree-walker, whose package.json `exports` field has no `require` condition. Under tsx's
+  // ESM loader, `require("ast-v8-to-istanbul")` resolves transitive imports with the require
+  // condition and dies on estree-walker with ERR_PACKAGE_PATH_NOT_EXPORTED. Dynamic import
+  // resolves with the import condition throughout and works under both plain Node and tsx.
+  const { convert } = await import("ast-v8-to-istanbul");
   const data: V8CoverageData = preParsedData ?? JSON.parse(fs.readFileSync(v8FilePath, "utf-8"));
   const coverage: CoverageResult = {};
 


### PR DESCRIPTION
Switch `require("ast-v8-to-istanbul")` to `await import("ast-v8-to-istanbul")` in `coverageProcessor.ts` so coverage works for SDK consumers running their service via `tsx`.

### The bug

`ast-v8-to-istanbul` is ESM-only and pulls in `estree-walker`, whose `package.json` `exports` field declares only an `import` condition (no `require`). Under plain Node, `require()` of an ESM module loaded via require-esm resolves transitive imports with the import condition and the chain works. Under **tsx**'s ESM loader, the same `require` resolves transitive imports with the *require* condition, falls off `estree-walker`'s exports map, and throws `ERR_PACKAGE_PATH_NOT_EXPORTED` — every coverage snapshot fails and no per-test coverage data is sent back to the CLI.

The error caught from CI logs:

```
[TuskDrift] [ProtobufCommunicator] Coverage snapshot error: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]:
No "exports" main defined in .../node_modules/.pnpm/ast-v8-to-istanbul@1.0.0/node_modules/estree-walker/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:322:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:613:13)
    at resolveExports (node:internal/modules/cjs/loader:638:36)
    at Module._findPath (node:internal/modules/cjs/loader:711:31)
    at nextResolveSimple (.../tsx@4.21.0/dist/register-D46fvsV_.cjs:4:1004)
    ...
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
```

The `tsx@4.21.0/.../register-D46fvsV_.cjs` frame is what flips resolution into the require condition.

### Why dynamic import vs other approaches

- **`createRequire(import.meta.url)("ast-v8-to-istanbul")`** has the same failure mode — it's still going through Node's `require` path.
- **Pinning `estree-walker` to a version with a `require` condition** isn't possible — it doesn't have one in any version.
- **Inlining ast-v8-to-istanbul** is heavy and removes a maintained dep.

Dynamic `import()` is the right primitive here: it resolves with the `import` condition unconditionally, regardless of which loader is active. The function is already `async` so there's no structural change.
